### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#pydown
+# pydown
 pydown is another "Presentation System in a single HTML page" written by python inspired by [keydown](https://github.com/infews/keydown).
 
 Like keydown it uses the [deck.js](http://imakewebthings.github.com/deck.js) and its extentions for the presentation.
 
-##Demo
+## Demo
 [http://isnowfy.github.io/pydown/](http://isnowfy.github.io/pydown/)
 
-##Usage
+## Usage
 
-###Write your slides in markdown
+### Write your slides in markdown
 Edit slides.md
 ~~~~
 !SLIDE
@@ -24,7 +24,7 @@ Edit slides.md
 # left
 ~~~~
 
-###Generate the html
+### Generate the html
 
 ~~~~
 $ python main.py slides.md slides
@@ -47,14 +47,14 @@ This will make:
   | - index.html
 ~~~~
 
-###Slide classes
+### Slide classes
 
 Any text follows !SLIDE will be added to the slide as css classes
 ~~~~
 !SLIDE left
 ~~~~
 
-###Syntax Highlighting
+### Syntax Highlighting
 
 For python
 <pre>
@@ -64,7 +64,7 @@ For python
 ~~~~
 </pre>
 
-###Markdown syntax
+### Markdown syntax
 
 [English version](http://daringfireball.net/projects/markdown/syntax)
 

--- a/introduction.md
+++ b/introduction.md
@@ -1,15 +1,15 @@
 !SLIDE
 
-#pydown
+# pydown
 
 !SLIDE
 
-##Markdown + deck.js
-##Simple html presentation maker
-##You just need to write markdown file
+## Markdown + deck.js
+## Simple html presentation maker
+## You just need to write markdown file
 
 !SLIDE
-##Support code highlighting
+## Support code highlighting
 
 ~~~~{python}
 def hello():
@@ -18,19 +18,19 @@ def hello():
 
 !SLIDE left
 
-##You can customize with css
-###like dropping the centering
+## You can customize with css
+### like dropping the centering
 
 !SLIDE left
 
-##Easy to use
+## Easy to use
 
 1. write your slides markdown file
 2. python main.py md directory
 
 !SLIDE
 
-##The previous slide just looks like this
+## The previous slide just looks like this
 
 ~~~~
  !SLIDE left
@@ -43,7 +43,7 @@ def hello():
 
 !SLIDE
 
-##Supports Markdown extensions
+## Supports Markdown extensions
 
 Like Markdown Extra
 {: .slide}
@@ -57,12 +57,12 @@ which allows for things adding additional attributes to markdown
 
 !SLIDE
 
-##Just simple
-##and enjoy yourself
+## Just simple
+## and enjoy yourself
 
 !SLIDE
 
-#Thanks
-##[isnowfy](http://www.isnowfy.com)|[isnowfy](https://github.com/isnowfy) on Github
-###Made by [pydown](https://github.com/isnowfy/pydown)
-###Inspired by [keydown](https://github.com/infews/keydown)
+# Thanks
+## [isnowfy](http://www.isnowfy.com)|[isnowfy](https://github.com/isnowfy) on Github
+### Made by [pydown](https://github.com/isnowfy/pydown)
+### Inspired by [keydown](https://github.com/infews/keydown)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
